### PR TITLE
Removed maven-source-plugin to avoid multiple deployment of the artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,18 +137,6 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
-			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Previously, Jenkins tried to publish the artifacts more than once and that created a build failure. I fixed this problem following Richard's advise.

Best,
Chris
